### PR TITLE
Revamp hero section with responsive layout

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -5,32 +5,34 @@ export default function LandingPage() {
   return (
     <main className="bg-white text-gray-900 font-sans">
       {/* Hero Section */}
-      <section className="relative text-white pt-[180px] pb-[120px] text-center">
-  {/* Разделённый фон */}
-  <div className="absolute inset-0">
-    <div className="h-[35%] bg-white" />
-    <div className="h-[65%] bg-purple-600" />
-  </div>
-
-  <div className="relative container mx-auto px-6 flex flex-col items-center">
-    {/* ЛОГОТИП */}
-    <div className="-mt-[180px] mb-6">
-      <img src="/logo.png" alt="Suppora Logo" className="w-[180px] h-[180px]" />
-    </div>
-
-    {/* ТЕКСТ */}
-    <div className="mt-10">
-      <h1 className="text-5xl font-bold mb-4">Scalable Human-Centered Tech Support</h1>
-      <p className="text-lg mb-6">Remote-first L1 & L2 support for startups, SaaS & fintech companies</p>
-      <a
-        href="#contact"
-        className="inline-block bg-white text-purple-700 font-semibold py-2 px-6 rounded-xl hover:bg-purple-100 transition"
-      >
-        Let’s Talk
-      </a>
-    </div>
-  </div>
-</section>
+      <section className="relative py-24 bg-gradient-to-b from-purple-600 to-purple-700 text-white">
+        <img
+          src="/logo.svg"
+          className="w-[100px] absolute top-6 left-6"
+          alt="Suppora Logo"
+        />
+        <div className="container mx-auto px-6 flex flex-col md:flex-row items-center justify-center text-center md:text-left space-y-6 md:space-y-0">
+          <div className="md:w-1/2">
+            <h1 className="text-4xl md:text-5xl font-bold text-center mb-4">
+              Scalable Human-Centered Tech Support
+            </h1>
+            <p className="text-lg text-center mb-6">
+              Remote-first L1 & L2 support for startups, SaaS & fintech companies
+            </p>
+            <a
+              href="#contact"
+              className="bg-white text-purple-700 font-semibold py-3 px-8 rounded-xl shadow hover:scale-105 transition"
+            >
+              Let’s Talk
+            </a>
+          </div>
+          <img
+            src="/illustration-placeholder.svg"
+            className="hidden md:block md:w-1/2"
+            alt="Illustration"
+          />
+        </div>
+      </section>
 
 
 

--- a/public/illustration-placeholder.svg
+++ b/public/illustration-placeholder.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300">
+  <rect width="400" height="300" rx="20" fill="#e5e7eb"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="24" fill="#6b7280" font-family="Arial, Helvetica, sans-serif">Illustration</text>
+</svg>

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" rx="20" fill="#7e22ce"/>
+  <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle" font-size="48" fill="white" font-family="Arial, Helvetica, sans-serif">S</text>
+</svg>


### PR DESCRIPTION
## Summary
- redesign hero with purple gradient, left-aligned logo, and responsive flex container
- add headline, subheadline, CTA button, and desktop-only illustration
- add placeholder logo.svg and illustration assets

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires interactive setup)


------
https://chatgpt.com/codex/tasks/task_e_68a86d07ae5c832982d38830ad687658